### PR TITLE
go: Verify user session before retrieving user ID

### DIFF
--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -242,6 +242,9 @@ func searchLivestreamsHandler(c echo.Context) error {
 
 func getUserLivestreamsHandler(c echo.Context) error {
 	ctx := c.Request().Context()
+	if err := verifyUserSession(c); err != nil {
+		return err
+	}
 
 	tx, err := dbConn.BeginTxx(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
getUserLivestreamsHandler() はセッションからユーザ ID を取り出してますが、このハンドラだけ事前に verifyUserSession() をしておらず EXPIRES のチェックが抜けてそうです。