### PR TITLE
go: Commit transaction in getUserLivestreamsHandler()

### DIFF
--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -264,6 +264,10 @@ func getUserLivestreamsHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
+	if err := tx.Commit(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
 	return c.JSON(http.StatusOK, livestreams)
 }
 


### PR DESCRIPTION
DB に書き込みを行ってないので意味が無いといえば無さそうですが、同様の読み込みのみの他のハンドラでは最後に commit しているので、getUserLivestreamsHandler() でもそれらに合わせて commit するようにします。