### PR TITLE
go: Remove unused UserID field in UserRankingEntry

### DIFF
--- a/webapp/go/stats_handler.go
+++ b/webapp/go/stats_handler.go
@@ -45,7 +45,6 @@ type UserStatistics struct {
 }
 
 type UserRankingEntry struct {
-	UserID   int64
 	UserName string
 	Score    int64
 }
@@ -111,7 +110,6 @@ func getUserStatisticsHandler(c echo.Context) error {
 
 		score := reactions + tips
 		ranking = append(ranking, UserRankingEntry{
-			UserID:   user.ID,
 			UserName: user.Name,
 			Score:    score,
 		})


### PR DESCRIPTION
UserRankingEntry の UserID フィールドは使われておらず、そのまま Rust に移植するとデフォルトで field `user_id` is never read という warning が出るので消したいです。