### PR TITLE
bench: Serialize tags to empty array instead of null

### DIFF
--- a/bench/isupipe/client_top.go
+++ b/bench/isupipe/client_top.go
@@ -64,7 +64,7 @@ func (c *Client) GetRandomTags(ctx context.Context, n int) ([]int64, error) {
 		resp.Tags[i], resp.Tags[j] = resp.Tags[j], resp.Tags[i]
 	})
 
-	var tags []int64
+	tags := []int64{}
 	for i := 0; i < n; i++ {
 		tags = append(tags, resp.Tags[i].ID)
 	}

--- a/bench/scenario/core_data_pretest.go
+++ b/bench/scenario/core_data_pretest.go
@@ -68,7 +68,7 @@ func Pretest(ctx context.Context, client *isupipe.Client) error {
 		tagStartIdx = rand.Intn(len(tagResponse.Tags))
 		tagEndIdx   = min(tagStartIdx+tagCount, len(tagResponse.Tags))
 	)
-	var tags []int64
+	tags := []int64{}
 	for _, tag := range tagResponse.Tags[tagStartIdx:tagEndIdx] {
 		tags = append(tags, int64(tag.ID))
 	}


### PR DESCRIPTION
In Golang, an empty slice and nil (zero value) are treated similarly. However they differ when serialized with encoding/json. https://go.dev/play/p/8KliOu7GRrx

----

↑の Go Playground の実行結果を見ると分かるように、空のスライスとスライスのゼロ値 (nil) は len() や append() においては同じように扱われますが JSON にシリアライズしたとき等に差があります。pretest のときに tagCount、tagStartIdx に選ばれた値によっては tags に一度も append() されず nil のままになり、webapp にリクエストするときにも `"tags": null` とシリアライズされてしまっていました。
なので nil ではなく空のスライスで初期化することで常に tags が null にシリアライズされないようにします。
GetRandomTags() のほうはランダムにシャッフルして先頭5個を取り出しているので空になる可能性は現時点では無さそうですが、今後の変更によっては空の可能性が出てくるかもしれないので一応揃えました。