### PR TITLE
bench: Fix tags serialization in test

### DIFF
--- a/bench/isupipe/client_livecomment_test.go
+++ b/bench/isupipe/client_livecomment_test.go
@@ -48,6 +48,7 @@ func TestGetNgWordsBug(t *testing.T) {
 		ThumbnailUrl: "https://example.com",
 		StartAt:      time.Date(2024, 4, 20, 0, 0, 0, 0, time.UTC).Unix(),
 		EndAt:        time.Date(2024, 4, 20, 5, 0, 0, 0, time.UTC).Unix(),
+		Tags:         []int64{},
 	})
 	assert.NoError(t, err)
 

--- a/bench/isupipe/client_livestream_test.go
+++ b/bench/isupipe/client_livestream_test.go
@@ -57,6 +57,7 @@ func TestLivestream(t *testing.T) {
 		ThumbnailUrl: "https://example.com",
 		StartAt:      time.Date(2024, 3, 31, 23, 59, 59, 0, time.UTC).Unix(),
 		EndAt:        time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC).Unix(),
+		Tags:         []int64{},
 	}, WithStatusCode(http.StatusBadRequest))
 	assert.NoError(t, err)
 	_, err = client.ReserveLivestream(ctx, &ReserveLivestreamRequest{
@@ -66,6 +67,7 @@ func TestLivestream(t *testing.T) {
 		ThumbnailUrl: "https://example.com",
 		StartAt:      time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		EndAt:        time.Date(2025, 4, 1, 1, 0, 0, 0, time.UTC).Unix(),
+		Tags:         []int64{},
 	}, WithStatusCode(http.StatusBadRequest))
 	assert.NoError(t, err)
 
@@ -105,6 +107,7 @@ func TestLivestream(t *testing.T) {
 				ThumbnailUrl: "https://example.com",
 				StartAt:      startAt,
 				EndAt:        endAt,
+				Tags:         []int64{},
 			}, WithStatusCode(http.StatusBadRequest))
 		} else {
 			_, err = loopClient.ReserveLivestream(ctx, &ReserveLivestreamRequest{
@@ -114,6 +117,7 @@ func TestLivestream(t *testing.T) {
 				ThumbnailUrl: "https://example.com",
 				StartAt:      startAt,
 				EndAt:        endAt,
+				Tags:         []int64{},
 			})
 		}
 		assert.NoError(t, err)

--- a/bench/isupipe/client_stats_test.go
+++ b/bench/isupipe/client_stats_test.go
@@ -60,6 +60,7 @@ func TestGetUserStats(t *testing.T) {
 		ThumbnailUrl: "https://example.com",
 		StartAt:      time.Date(2024, 11, 10, 0, 0, 0, 0, time.UTC).Unix(),
 		EndAt:        time.Date(2024, 11, 10, 4, 0, 0, 0, time.UTC).Unix(),
+		Tags:         []int64{},
 	})
 	assert.NoError(t, err)
 	livestream2, err := streamer1Client.ReserveLivestream(ctx, &ReserveLivestreamRequest{
@@ -69,6 +70,7 @@ func TestGetUserStats(t *testing.T) {
 		ThumbnailUrl: "https://example.com",
 		StartAt:      time.Date(2024, 11, 24, 0, 0, 0, 0, time.UTC).Unix(),
 		EndAt:        time.Date(2024, 11, 24, 9, 0, 0, 0, time.UTC).Unix(),
+		Tags:         []int64{},
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
#154 と同様の問題が bench のテストケースにも存在していたので直します。