### PR TITLE
bench: Set content-type header to PostIcon API

### DIFF
--- a/bench/isupipe/client_user.go
+++ b/bench/isupipe/client_user.go
@@ -143,6 +143,7 @@ func (c *Client) PostIcon(ctx context.Context, r *PostIconRequest, opts ...Clien
 	if err != nil {
 		return nil, bencherror.NewInternalError(err)
 	}
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
ベンチマーカが `POST /api/icon` にリクエストするときに content-type ヘッダが抜けているのを直します。