### PR TITLE
bench: Fix typo chatset -> charset

### DIFF
--- a/bench/isupipe/client_initialize.go
+++ b/bench/isupipe/client_initialize.go
@@ -17,7 +17,7 @@ func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := c.agent.Do(ctx, req)
 	if err != nil {

--- a/bench/isupipe/client_livecomment.go
+++ b/bench/isupipe/client_livecomment.go
@@ -179,7 +179,7 @@ func (c *Client) PostLivecomment(ctx context.Context, livestreamID int64, r *Pos
 	if err != nil {
 		return nil, bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {
@@ -219,7 +219,7 @@ func (c *Client) ReportLivecomment(ctx context.Context, livestreamID, livecommen
 	if err != nil {
 		return bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {
@@ -256,7 +256,7 @@ func (c *Client) Moderate(ctx context.Context, livestreamID int64, ngWord string
 	if err != nil {
 		return bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {

--- a/bench/isupipe/client_livestream.go
+++ b/bench/isupipe/client_livestream.go
@@ -192,7 +192,7 @@ func (c *Client) ReserveLivestream(ctx context.Context, r *ReserveLivestreamRequ
 	if err != nil {
 		return nil, bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.themeAgent, req)
 	if err != nil {
@@ -227,7 +227,7 @@ func (c *Client) EnterLivestream(ctx context.Context, livestreamID int64, opts .
 	if err != nil {
 		return bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {

--- a/bench/isupipe/client_reaction.go
+++ b/bench/isupipe/client_reaction.go
@@ -76,7 +76,7 @@ func (c *Client) PostReaction(ctx context.Context, livestreamID int64, r *PostRe
 	if err != nil {
 		return nil, bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {

--- a/bench/isupipe/client_user.go
+++ b/bench/isupipe/client_user.go
@@ -244,7 +244,7 @@ func (c *Client) Register(ctx context.Context, r *RegisterRequest, opts ...Clien
 	if err != nil {
 		return nil, bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {
@@ -288,7 +288,7 @@ func (c *Client) Login(ctx context.Context, r *LoginRequest, opts ...ClientOptio
 	if err != nil {
 		return bencherror.NewInternalError(err)
 	}
-	req.Header.Add("Content-Type", "application/json;chatset=utf-8")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := sendRequest(ctx, c.agent, req)
 	if err != nil {


### PR DESCRIPTION
#142 と同様の typo がベンチマーカにも存在しているのを直します。