### PR TITLE
moderationのバグ修正

### DIFF
--- a/webapp/go/livecomment_handler.go
+++ b/webapp/go/livecomment_handler.go
@@ -371,6 +371,7 @@ func moderateHandler(c echo.Context) error {
 			query := `
 			DELETE FROM livecomments
 			WHERE
+			id = ? AND
 			(SELECT COUNT(*)
 			FROM
 			(SELECT ? AS text) AS texts
@@ -378,7 +379,7 @@ func moderateHandler(c echo.Context) error {
 			(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
 			ON texts.text LIKE patterns.pattern) >= 1;
 			`
-			if _, err := tx.ExecContext(ctx, query, livecomment.Comment, ngword.Word); err != nil {
+			if _, err := tx.ExecContext(ctx, query, livecomment.ID, livecomment.Comment, ngword.Word); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams")
 			}
 		}

--- a/webapp/sql/initdb.d/10_schema.sql
+++ b/webapp/sql/initdb.d/10_schema.sql
@@ -94,7 +94,7 @@ CREATE TABLE `livecomment_reports` (
   `created_at` BIGINT NOT NULL,
   CONSTRAINT FK_livecomment_reports_user_id FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT FK_livecomment_reports_livestream_id FOREIGN KEY (`livestream_id`) REFERENCES `livestreams` (`id`),
-  CONSTRAINT FK_livecomment_reports_livecomment_id FOREIGN KEY (`livecomment_id`) REFERENCES `livecomments` (`id`)
+  CONSTRAINT FK_livecomment_reports_livecomment_id FOREIGN KEY (`livecomment_id`) REFERENCES `livecomments` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- 配信者からのNGワード登録


### PR DESCRIPTION
Moderationによる古いスパムコメント削除処理にて、以下問題を修正

* livecommentsテーブルを親とするlivecomment_reportsテーブルの外部キー制約に `ON CASCADE DELETE` を追加することにより、暗黙的に関係するレコードの削除が走るように
* livecomment_idを考慮しておらず、すべてのライブコメントが粛清される問題を修正

https://github.com/isucon/isucon13/issues/138