### PR TITLE
bench: Serialize tags to empty array

### DIFF
--- a/bench/scenario/core_pretest_abnormal.go
+++ b/bench/scenario/core_pretest_abnormal.go
@@ -143,6 +143,7 @@ func assertReserveOverflowPretest(ctx context.Context, dnsResolver *resolver.DNS
 			endAt   = time.Date(2024, 4, 1, 1, 0, 0, 0, time.Local)
 		)
 		_, err = overflowClient.ReserveLivestream(ctx, &isupipe.ReserveLivestreamRequest{
+			Tags:        []int64{},
 			Title:       name,
 			Description: name,
 			// FIXME: フロントで困らないようにちゃんとしたのを設定
@@ -185,6 +186,7 @@ func assertReserveOutOfTerm(ctx context.Context, testUser *isupipe.User, dnsReso
 		endAt   = time.Date(2026, 4, 1, 1, 0, 0, 0, time.Local)
 	)
 	if _, err := client.ReserveLivestream(ctx, &isupipe.ReserveLivestreamRequest{
+		Tags:         []int64{},
 		Title:        "outofterm",
 		Description:  "outofterm",
 		PlaylistUrl:  "",
@@ -200,6 +202,7 @@ func assertReserveOutOfTerm(ctx context.Context, testUser *isupipe.User, dnsReso
 		endAt2   = time.Date(2023, 4, 1, 1, 0, 0, 0, time.Local)
 	)
 	if _, err := client.ReserveLivestream(ctx, &isupipe.ReserveLivestreamRequest{
+		Tags:         []int64{},
 		Title:        "outofterm",
 		Description:  "outofterm",
 		PlaylistUrl:  "",


### PR DESCRIPTION
#154 や  #157 と同様の問題を直します。
もし POST /api/livestream/reservation において tags が null になり得るという仕様である場合は、それに合わせて Rust 側の実装を直すことは可能です。

また、この PR では変更していませんが、POST /api/livestream/reservation のチェック時に400以外すべてに対して「期間外予約が不正にできてしまいます」というエラーメッセージを返すのは競技者に分かりづらいかなと思いました。たとえば何らかのバグで422や500等を返してしまったときも「期間外予約が不正にできてしまいます」となってしまいますし。
https://github.com/isucon/isucon13/blob/18609cfa37c978cb3b6499a20d211cc28f5e7097/bench/scenario/core_pretest_abnormal.go#L187-L211
ISUCON12 での実装を見ると、期待していたステータスコードでないという旨のエラーメッセージになってそうです。
https://github.com/isucon/isucon12-final/blob/d31d92c7f0df9fa1559270ffb9481ec8a610edf0/benchmarker/validation.go#L162-L188
https://github.com/isucon/isucon12-qualify/blob/3c1451cce32b85036dcff29bcf122ea83681dbd3/bench/validation.go#L137-L157