### PR TITLE
bench run --pretest-onlyを追加

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -177,6 +177,7 @@ var run = cli.Command{
 		if err := scenario.Pretest(ctx, pretestDNSResolver); err != nil {
 			return cli.NewExitError(err, 1)
 		}
+		lgr.Info("整合性チェックが成功しました")
 
 		if pretestOnly {
 			lgr.Info("--pretest-onlyが指定されているため、ベンチマーク走行をスキップします")


### PR DESCRIPTION
移植時など、pretestだけ実行したい場合に便利のはず

```console
$ ./bin/bench_linux_amd64 run -target https://pipe.u.isucon.dev -nameserver 163.43.188.171 --enable-ssl --pretest-only
2023-11-15T01:35:16.180Z	info	isupipe-benchmarker	SSLが有効になっています
2023-11-15T01:35:16.180Z	info	isupipe-benchmarker	webapp: https://pipe.u.isucon.dev
2023-11-15T01:35:16.180Z	info	isupipe-benchmarker	nameserver: 163.43.188.171:53
2023-11-15T01:35:16.180Z	info	isupipe-benchmarker	===== Prepare benchmarker =====
2023-11-15T01:35:16.180Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-15T01:35:17.237Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-15T01:35:17.707Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-15T01:35:17.707Z	info	isupipe-benchmarker	--pretest-onlyが指定されているため、ベンチマーク走行をスキップします
```