### PR TITLE
Add error checking for insufficient number of tags in NormalLivestreamPretest

### DIFF
--- a/bench/scenario/core_pretest_normal.go
+++ b/bench/scenario/core_pretest_normal.go
@@ -95,6 +95,9 @@ func NormalLivestreamPretest(ctx context.Context, testUser *isupipe.User, dnsRes
 		tagStartIdx = rand.Intn(len(tagResponse.Tags))
 		tagEndIdx   = min(tagStartIdx+tagCount, len(tagResponse.Tags))
 	)
+	if len(tagResponse.Tags) < tagEndIdx {
+		return fmt.Errorf("タグの数が足りません")
+	}
 	tags := []int64{}
 	for _, tag := range tagResponse.Tags[tagStartIdx:tagEndIdx] {
 		tags = append(tags, int64(tag.ID))


### PR DESCRIPTION
エラーの扱いがよく分かってないですが、とりあえずPRにしておきます