### PR TITLE
bench: Serialize tags to empty array (4)

### DIFF
--- a/bench/scenario/core_pretest_abnormal.go
+++ b/bench/scenario/core_pretest_abnormal.go
@@ -150,6 +150,7 @@ func assertReserveOverflowPretest(ctx context.Context, dnsResolver *resolver.DNS
 			ThumbnailUrl: "",
 			StartAt:      startAt.Unix(),
 			EndAt:        endAt.Unix(),
+			Tags:         []int64{},
 		})
 		if err != nil {
 			overflow = true
@@ -191,6 +192,7 @@ func assertReserveOutOfTerm(ctx context.Context, testUser *isupipe.User, dnsReso
 		ThumbnailUrl: "",
 		StartAt:      startAt.Unix(),
 		EndAt:        endAt.Unix(),
+		Tags:         []int64{},
 	}, isupipe.WithStatusCode(http.StatusBadRequest)); err != nil {
 		return fmt.Errorf("期間外予約が不正にできてしまいます")
 	}
@@ -206,6 +208,7 @@ func assertReserveOutOfTerm(ctx context.Context, testUser *isupipe.User, dnsReso
 		ThumbnailUrl: "",
 		StartAt:      startAt2.Unix(),
 		EndAt:        endAt2.Unix(),
+		Tags:         []int64{},
 	}, isupipe.WithStatusCode(http.StatusBadRequest)); err != nil {
 		return fmt.Errorf("期間外予約が不正にできてしまいます")
 	}


### PR DESCRIPTION
#154 、 #157 、 #236 と同様の修正です。