### PR TITLE
ベンチ実行前に前回の結果ファイルを削除する

### DIFF
--- a/bench/cmd/bench/supervise.go
+++ b/bench/cmd/bench/supervise.go
@@ -57,6 +57,14 @@ func execBench(ctx context.Context, job *Job) (*Result, error) {
 	}
 	log.Printf("executable = %s\n", executablePath)
 
+	// ベンチマーカー実行前に確実にresultファイルを削除する
+	// 他のチームに対する結果が含まれている可能性があるため
+	for _, name := range []string{resultPath, staffLogPath, contestantLogPath} {
+		if err := os.Remove(name); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
 	benchOptions := []string{
 		"run",
 		"--nameserver", target,


### PR DESCRIPTION
削除しないと、bench run実行後、結果ファイルの書き出し前
になんらかの原因でbenchが落ちた場合、以前の(他のチームに対する)
ベンチの結果が送信されてしまう可能性があります