### PR TITLE
checkip.awsをつかう

### DIFF
--- a/provisioning/ansible/roles/globalip/files/aws-env-isucon-subdomain-address.service
+++ b/provisioning/ansible/roles/globalip/files/aws-env-isucon-subdomain-address.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=run aws-env-isucon-subdomain-address once
+Wants=time-sync.target
+Before=time-sync.target
+After=network.target
+
+[Service]
+Restart=no
+Type=simple
+RemainAfterExit=yes
+ExecStart=/opt/aws-env-isucon-subdomain-address.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/provisioning/ansible/roles/globalip/files/aws-env-isucon-subdomain-address.sh
+++ b/provisioning/ansible/roles/globalip/files/aws-env-isucon-subdomain-address.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eux
+
+if (test -f /opt/aws-env-isucon-subdomain-address.sh.lock); then
+  exit
+fi
+
+touch /opt/aws-env-isucon-subdomain-address.sh.lock
+
+if !(grep Amazon /sys/devices/virtual/dmi/id/bios_vendor); then
+  exit
+fi
+
+instance_ip=$(curl -s https://checkip.amazonaws.com)
+if [ -n $instance_ip ]; then
+  sed -Ei 's/^ISUCON13_POWERDNS_SUBDOMAIN_ADDRESS=.+$/ISUCON13_POWERDNS_SUBDOMAIN_ADDRESS="'${instance_ip}'"/' /home/isucon/env.sh
+fi
+chmod 0755 /home/isucon/env.sh
+chown isucon:isucon /home/isucon/env.sh

--- a/provisioning/ansible/roles/globalip/tasks/main.yml
+++ b/provisioning/ansible/roles/globalip/tasks/main.yml
@@ -2,19 +2,7 @@
 - name: generator ISUCON_SUBDOMAIN_ADDRESS
   become: true
   copy:
-    content: |
-      #!/usr/bin/env bash
-      set -eux
-      if (test -f /opt/aws-env-isucon-subdomain-address.sh.lock); then
-        exit
-      fi
-      touch /opt/aws-env-isucon-subdomain-address.sh.lock
-      instance_ip=$(curl -m 10 -s curl http://169.254.169.254/latest/meta-data/public-ipv4)
-      if [ -n $instance_ip ]; then
-        sed -Ei 's/^ISUCON13_POWERDNS_SUBDOMAIN_ADDRESS=.+$/ISUCON13_POWERDNS_SUBDOMAIN_ADDRESS="'${instance_ip}'"/' /home/isucon/env.sh
-      fi
-      chmod 0755 /home/isucon/env.sh
-      chown isucon:isucon /home/isucon/env.sh
+    src: aws-env-isucon-subdomain-address.sh
     dest: /opt/aws-env-isucon-subdomain-address.sh
     owner: root
     group: root
@@ -23,22 +11,10 @@
 - name: generator ISUCON_SUBDOMAIN_ADDRESS service
   become: true
   copy:
-    content: |
-      [Unit]
-      Description=run aws-env-isucon-subdomain-address once
-      Wants=time-sync.target
-      Before=time-sync.target
-      After=network.target
-      
-      [Service]
-      Restart=no
-      Type=simple
-      RemainAfterExit=yes
-      ExecStart=/opt/aws-env-isucon-subdomain-address.sh
-      
-      [Install]
-      WantedBy=multi-user.target
+    src: aws-env-isucon-subdomain-address.service
     dest: /etc/systemd/system/aws-env-isucon-subdomain-address.service
+    owner: root
+    group: root
     mode: 0644
 
 - name: Enable test service


### PR DESCRIPTION
instance metadata serviceが初回起動時に404になるので方式変更