### PR TITLE
Fix/cheat ngword

### DIFF
--- a/bench/scenario/core_pretest_normal.go
+++ b/bench/scenario/core_pretest_normal.go
@@ -682,18 +682,18 @@ func NormalModerateLivecommentPretest(ctx context.Context, testUser *isupipe.Use
 		// spamではない普通のコメントをする
 		tip := rand.Intn(100)
 		livecomment := scheduler.LivecommentScheduler.GetLongPositiveComment()
-		r, _, err := spammerClient.PostLivecomment(ctx, livestream.ID, livestream.Owner.Name, livecomment.Comment, &scheduler.Tip{})
+		r, _, err := spammerClient.PostLivecomment(ctx, livestream.ID, livestream.Owner.Name, livecomment.Comment, &scheduler.Tip{Tip: tip})
 		if err != nil {
 			return err
 		}
 		if r.Livestream.ID != livestream.ID {
-			return fmt.Errorf("投稿されたライブコメントのlivestream.IDが正しくありません")
+			return fmt.Errorf("投稿されたライブコメントのlivestream.IDが正しくありません expected:%d actual:%d", livestream.ID, r.Livestream.ID)
 		}
 		if r.Livestream.Owner.Name != livestream.Owner.Name {
-			return fmt.Errorf("投稿されたライブコメントのOwnerが正しくありません")
+			return fmt.Errorf("投稿されたライブコメントのOwnerが正しくありません expected:%s actual:%s", livestream.Owner.Name, r.Livestream.Owner.Name)
 		}
 		if r.Tip != int64(tip) {
-			return fmt.Errorf("投稿されたライブコメントのTipが正しくありません")
+			return fmt.Errorf("投稿されたライブコメントのTipが正しくありません expected:%d actual:%d", tip, r.Tip)
 		}
 		added++
 	}


### PR DESCRIPTION
- ng_word判定を丸ごとコメントアウトして通るチート対策
- fillLivecommentResponse で、User, Livestream に空の値を詰めて返すチート対策

refs #298 