### PR TITLE
send private-ipv4 too

### DIFF
--- a/envcheck/aws.go
+++ b/envcheck/aws.go
@@ -36,6 +36,10 @@ func GetPublicIP(svc *ec2metadata.EC2Metadata) (string, error) {
 	return svc.GetMetadata("public-ipv4")
 }
 
+func GetLocalIP(svc *ec2metadata.EC2Metadata) (string, error) {
+	return svc.GetMetadata("local-ipv4")
+}
+
 func GetVPC(svc *ec2metadata.EC2Metadata) (string, error) {
 	s, err := net.Interfaces()
 	if err != nil {

--- a/envcheck/checker.go
+++ b/envcheck/checker.go
@@ -22,8 +22,9 @@ type checker struct {
 	ExpectedAMI string
 	ExpectedAZ  string
 
-	InstanceIP    string
-	InstanceVPCID string
+	InstanceIP      string
+	InstanceLocalIP string
+	InstanceVPCID   string
 
 	DescribeInstances         []*ec2.DescribeInstancesOutput
 	DescribeVolumes           []*ec2.DescribeVolumesOutput
@@ -39,12 +40,13 @@ type checker struct {
 }
 
 type Result struct {
-	Name         string
-	Passed       bool
-	IPAddress    string
-	Message      string
-	AdminMessage string
-	RawData      string
+	Name           string
+	Passed         bool
+	IPAddress      string
+	LocalIPAddress string
+	Message        string
+	AdminMessage   string
+	RawData        string
 }
 
 func Check(cfg CheckConfig) (Result, error) {
@@ -73,12 +75,13 @@ func Check(cfg CheckConfig) (Result, error) {
 
 	raw, _ := json.Marshal(c)
 	return Result{
-		Name:         cfg.Name,
-		Passed:       len(c.failures) == 0,
-		IPAddress:    c.InstanceIP,
-		Message:      c.message(),
-		AdminMessage: c.adminLog.String(),
-		RawData:      string(raw),
+		Name:           cfg.Name,
+		Passed:         len(c.failures) == 0,
+		IPAddress:      c.InstanceIP,
+		LocalIPAddress: c.InstanceLocalIP,
+		Message:        c.message(),
+		AdminMessage:   c.adminLog.String(),
+		RawData:        string(raw),
 	}, nil
 }
 
@@ -93,6 +96,10 @@ func (c *checker) loadAWS() error {
 	c.InstanceIP, err = GetPublicIP(ec2md)
 	if err != nil {
 		return fmt.Errorf("GetPublicIP: %w", err)
+	}
+	c.InstanceLocalIP, err = GetLocalIP(ec2md)
+	if err != nil {
+		return fmt.Errorf("GetLocalIP: %w", err)
 	}
 	c.InstanceVPCID, err = GetVPC(ec2md)
 	if err != nil {

--- a/envcheck/portal.go
+++ b/envcheck/portal.go
@@ -87,7 +87,7 @@ func (p *Portal) SendResult(r Result) error {
 	}{
 		Name:         r.Name,
 		Passed:       r.Passed,
-		IPAddress:    r.IPAddress,
+		IPAddress:    r.LocalIPAddress,
 		Message:      r.Message,
 		AdminMessage: r.AdminMessage,
 		RawData:      r.RawData,


### PR DESCRIPTION
globalipは、portalでclient ipをセットする。
ipはプライベートipを送っておくのが吉