### PR TITLE
go: /api/user/:username/livestream: Return 404 when username is not found

### DIFF
--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -289,7 +289,11 @@ func getUserLivestreamsHandler(c echo.Context) error {
 
 	var user UserModel
 	if err := tx.GetContext(ctx, &user, "SELECT * FROM users WHERE name = ?", username); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "failed to get user")
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "user not found")
+		} else {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user: "+err.Error())
+		}
 	}
 
 	var livestreamModels []*LivestreamModel


### PR DESCRIPTION
他のエンドポイントの挙動に合わせると `GET /api/user/:username/livestream` で指定された username のユーザが存在しなかったときは 404 を返すのが正しいのかなと思ったんですがどうでしょうか。