### PR TITLE
conditional getじゃないのに304が来たらエラーにする

### DIFF
--- a/bench/isupipe/client_user.go
+++ b/bench/isupipe/client_user.go
@@ -114,7 +114,9 @@ func (c *Client) GetIcon(ctx context.Context, username string, opts ...ClientOpt
 	var imageBytes []byte
 	switch resp.StatusCode {
 	case http.StatusNotModified:
-		// 304の場合はbodyは見ない
+		if o.eTag == "" {
+			return nil, bencherror.NewInternalError(fmt.Errorf("If-None-Matchを指定していないのに304が返却されました"))
+		}
 	case defaultStatusCode:
 		imageBytes, err = io.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
iconで常に304を返す、みたいなチートをしたときに分かりやすく失敗させます。