### PR TITLE
fix: goldenimage refers to the base image

### DIFF
--- a/provisioning/packer/isucon13.pkr.hcl
+++ b/provisioning/packer/isucon13.pkr.hcl
@@ -52,9 +52,9 @@ source "amazon-ebs" "isucon13" {
   tags          = local.ami_tags
   snapshot_tags = local.ami_tags
 
-  source_ami    = "${data.amazon-ami.ubuntu-jammy.id}"
+  source_ami    = "ami-03bd3273f34a1f122"
   region        = "ap-northeast-1"
-  instance_type = "t3.medium"
+  instance_type = "t3.xlarge"
 
   run_tags        = local.run_tags
   run_volume_tags = local.run_tags

--- a/provisioning/packer/isucon13_base_image.pkr.hcl
+++ b/provisioning/packer/isucon13_base_image.pkr.hcl
@@ -49,7 +49,7 @@ source "amazon-ebs" "isucon13" {
 
   source_ami    = "${data.amazon-ami.ubuntu-jammy.id}"
   region        = "ap-northeast-1"
-  instance_type = "t3.medium"
+  instance_type = "t3.xlarge"
 
   run_tags        = local.run_tags
   run_volume_tags = local.run_tags


### PR DESCRIPTION
ゴールデンイメージ作成は、各言語のランタイムが入ったベースイメージを参照するように変更