### PR TITLE
[WIP] NGINX(443) から直接 PHP-FPM を叩くように NGINX の設定ファイルを修正

### DIFF
--- a/provisioning/ansible/roles/nginx/files/etc/nginx/sites-available/isupipe-php.conf
+++ b/provisioning/ansible/roles/nginx/files/etc/nginx/sites-available/isupipe-php.conf
@@ -1,13 +1,50 @@
 server {
-  listen 8080;
+  listen 80 default_server;
+  server_name _;
+  index index.html index.htm index.nginx-debian.html;
+  root /var/www/html;
+  location / {
+    try_files $uri $uri/ =404;
+  }
+}
 
-  client_max_body_size 10m;
-  root /home/isucon/webapp/php/public/;
+server {
+  listen 443 ssl default_server;
+  server_name _;
+  index index.html index.htm index.nginx-debian.html;
+  root /var/www/html;
+
+  # bot避けのためのvhostで、この証明書は有効期限がきれています
+  ssl_certificate     /etc/nginx/tls/_.t.isucon.dev.crt;
+  ssl_certificate_key /etc/nginx/tls/_.t.isucon.dev.key;
+  ssl_protocols       TLSv1.2 TLSv1.3;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
 
   location / {
-     try_files $uri /index.php$is_args$args;
+    try_files $uri $uri/ =404;
   }
+}
 
+server {
+  listen 443 ssl;
+  server_name u.isucon.dev;
+  server_name *.u.isucon.dev;
+
+  ssl_certificate     /etc/nginx/tls/_.u.isucon.dev.crt;
+  ssl_certificate_key /etc/nginx/tls/_.u.isucon.dev.key;
+
+  ssl_protocols TLSv1.3;
+  ssl_prefer_server_ciphers off;
+
+  client_max_body_size 10m;
+  root /home/isucon/webapp/public/;
+  location / {
+    try_files $uri /index.html;
+  }
+  location /api {
+    try_files /index.php$is_args$args;
+  }
   location = /index.php {
     include fastcgi_params;
     fastcgi_index index.php;


### PR DESCRIPTION
現状 NGINX(443) → NGINX(8080) → PHP-FPM となっているのを NGINX(443) → PHP-FPM となるように修正。

`isupipe-php.conf` に全部入りの設定を書くようになった都合上、マニュアル等にも影響出そうです。

## TODO

- [ ] 試し解き環境にて、修正後の設定ファイルで webapp が動きベンチマークをパスするのか確認


## 備考

変更前ベンチマーク結果

```plaintext
2023-11-23T06:07:57.625Z        info    staff-logger    bench/bench.go:267      ベンチエラーを収集します
2023-11-23T06:07:57.626Z        info    staff-logger    bench/bench.go:275      内部エラーを収集します
2023-11-23T06:07:57.626Z        info    staff-logger    bench/bench.go:291      シナリオカウンタを出力します
2023-11-23T06:07:57.626Z        info    staff-logger    bench/bench.go:310      [シナリオ aggressive-streamer-moderate] 11 回成功, 2 回失敗
2023-11-23T06:07:57.627Z        info    staff-logger    bench/bench.go:310      [シナリオ dns-watertorture-attack] 122 回成功
2023-11-23T06:07:57.627Z        info    staff-logger    bench/bench.go:310      [シナリオ streamer-cold-reserve] 16 回成功, 1 回失敗
2023-11-23T06:07:57.627Z        info    staff-logger    bench/bench.go:310      [シナリオ streamer-moderate] 4 回成功
2023-11-23T06:07:57.627Z        info    staff-logger    bench/bench.go:310      [シナリオ viewer-report] 10 回成功
2023-11-23T06:07:57.627Z        info    staff-logger    bench/bench.go:310      [シナリオ viewer-spam] 12 回成功, 1 回失敗
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:310      [失敗シナリオ aggressive-streamer-moderate-fail] 2 回失敗
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:310      [失敗シナリオ streamer-cold-reserve-fail] 1 回失敗
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:310      [失敗シナリオ viewer-spam-fail] 1 回失敗
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:316      名前解決成功数: 13073
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:317      名前解決失敗数: 0
2023-11-23T06:07:57.628Z        info    staff-logger    bench/bench.go:321      スコア: 600
```

変更後のベンチマーク結果

TODO