### PR TITLE
rust+ruby: Fix ranking calculations in stats

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -931,7 +931,8 @@ module Isupipe
         end
 
         ranking.sort_by! { |entry| [entry.score, entry.username] }
-        rank = ranking.rindex { |entry| entry.username == username } + 1
+        ridx = ranking.rindex { |entry| entry.username == username }
+        rank = ranking.size - ridx
 
         # リアクション数
         total_reactions = tx.xquery(<<~SQL, username, as: :array).first[0]
@@ -1009,7 +1010,8 @@ module Isupipe
           LivestreamRankingEntry.new(livestream_id: livestream.fetch(:id), score:)
         end
         ranking.sort_by! { |entry| [entry.score, entry.livestream_id] }
-        rank = ranking.rindex { |entry| entry.livestream_id == livestream_id } + 1
+        ridx = ranking.rindex { |entry| entry.livestream_id == livestream_id }
+        rank = ranking.size - ridx
 
 	# 視聴者数算出
         viewers_count = tx.xquery('SELECT COUNT(*) FROM livestreams l INNER JOIN livestream_viewers_history h ON h.livestream_id = l.id WHERE l.id = ?', livestream_id, as: :array).first[0]

--- a/webapp/rust/src/main.rs
+++ b/webapp/rust/src/main.rs
@@ -1887,11 +1887,11 @@ async fn get_user_statistics_handler(
             .then_with(|| a.username.cmp(b.username))
     });
 
-    let rank = ranking
+    let rpos = ranking
         .iter()
         .rposition(|entry| entry.username == username)
-        .unwrap_or(ranking.len()) as i64
-        + 1;
+        .unwrap();
+    let rank = (ranking.len() - rpos) as i64;
 
     // リアクション数
     let query = r"#
@@ -2019,11 +2019,11 @@ async fn get_livestream_statistics_handler(
             .then_with(|| a.livestream_id.cmp(&b.livestream_id))
     });
 
-    let rank = ranking
+    let rpos = ranking
         .iter()
         .rposition(|entry| entry.livestream_id == livestream_id)
-        .unwrap_or(ranking.len()) as i64
-        + 1;
+        .unwrap();
+    let rank = (ranking.len() - rpos) as i64;
 
     // 視聴者数算出
     let MysqlDecimal(viewers_count) = sqlx::query_scalar("SELECT COUNT(*) FROM livestreams l INNER JOIN livestream_viewers_history h ON h.livestream_id = l.id WHERE l.id = ?")


### PR DESCRIPTION
#352 に追従しつつ、rank 計算の移植をミスっていたのを修正します。

----

rank 計算の確認用 SQL メモ

```sql
select
  row_number() over (order by coalesce(r.cnt, 0) + coalesce(c.total_tip, 0) desc, l.livestream_id desc) as rnk
  , l.livestream_id
from
  (select id as livestream_id from livestreams) l
  left outer join (
    select
      livestream_id
      , count(1) as cnt
    from
      reactions
    group by 1
  ) r using (livestream_id)
  left outer join (
    select
      livestream_id
      , sum(tip) as total_tip
    from
      livecomments
    group by 1
) c using (livestream_id)
order by 1
```

```sql
select
  row_number() over (order by coalesce(r.cnt, 0) + coalesce(c.total_tip, 0) desc, u.name desc) as rnk
  , u.name
from
  (select id as user_id, name from users) u
  left outer join (
    select
      l.user_id
      , count(1) as cnt
    from
      reactions r
      inner join livestreams l on l.id = r.livestream_id
    group by 1
  ) r using (user_id)
  left outer join (
    select
      l.user_id
      , sum(c.tip) as total_tip
    from
      livecomments c
      inner join livestreams l on l.id = c.livestream_id
    group by 1
  ) c using (user_id)
order by 1
```