### PR TITLE
webapp: Remove meaningless FIXME comment on session values

### DIFF
--- a/webapp/go/user_handler.go
+++ b/webapp/go/user_handler.go
@@ -331,7 +331,6 @@ func loginHandler(c echo.Context) error {
 		Path:   "/",
 	}
 	sess.Values[defaultSessionIDKey] = sessionID
-	// FIXME: ユーザ名
 	sess.Values[defaultUserIDKey] = userModel.ID
 	sess.Values[defaultUsernameKey] = userModel.Name
 	sess.Values[defaultSessionExpiresKey] = sessionEndAt.Unix()

--- a/webapp/php/src/User/Handler.php
+++ b/webapp/php/src/User/Handler.php
@@ -367,7 +367,6 @@ class Handler extends AbstractHandler
 
         $this->session->id(true);
 
-        // FIXME: ユーザ名
         $this->session->set($this::DEFAULT_USER_ID_KEY, $userModel->id);
         $this->session->set($this::DEFAULT_USERNAME_KEY, $userModel->name);
         $this->session->set($this::DEFAULT_SESSION_EXPIRES_KEY, $sessionEndAt);

--- a/webapp/python/app.py
+++ b/webapp/python/app.py
@@ -1035,7 +1035,6 @@ def login_handler() -> tuple[str, int]:
         session_id = str(uuid.uuid4())
 
         session[Settings.DEFAULT_SESSION_ID_KEY] = session_id
-        # FIXME: ユーザ名
         session[Settings.DEFAULT_USER_ID_KEY] = user.id
         session[Settings.DEFAULT_USER_NAME_KEY] = user.name
         session[Settings.DEFAULT_SESSION_EXPIRES_KEY] = int(session_end_at.timestamp())

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -865,7 +865,6 @@ module Isupipe
       session_id = SecureRandom.uuid
       session[DEFAULT_SESSION_ID_KEY] = {
         DEFAULT_SESSION_ID_KEY => session_id,
-	# FIXME: ユーザ名
         DEFAULT_USER_ID_KEY => user_model.fetch(:id),
         DEFAULT_USERNAME_KEY => user_model.fetch(:name),
         DEFAULT_SESSION_EXPIRES_KEY => session_end_at.to_i,


### PR DESCRIPTION
セッションの値をセットしているところで、よく分からない「FIXME: ユーザ名」コメントが残っているのを消します。
セッションの値に userModel.Name を含めているものの使ってないので、ユーザ名を入れる意図は実際よく分かってませんが……