### PR TITLE
Stop stub resolver before starting PowerDNS

### DIFF
--- a/provisioning/ansible/roles/powerdns/tasks/main.yml
+++ b/provisioning/ansible/roles/powerdns/tasks/main.yml
@@ -1,4 +1,26 @@
 ---
+- name: Copy systemd/resolved.conf
+  become: true
+  copy:
+    src: resolved.conf
+    dest: /etc/systemd/resolved.conf
+    mode: 0644
+
+- name: symlink resolv.conf
+  become: true
+  file:
+    src: /run/systemd/resolve/resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: true
+
+- name: Restart systemd-resolved
+  become: true
+  service:
+    name: systemd-resolved
+    enabled: true
+    state: restarted
+
 - name: Copy sources.list.d/pdns.list
   become: true
   copy:
@@ -87,28 +109,6 @@
     src: pdns.conf
     dest: /etc/powerdns/pdns.conf
     mode: 0644
-
-- name: Copy systemd/resolved.conf
-  become: true
-  copy:
-    src: resolved.conf
-    dest: /etc/systemd/resolved.conf
-    mode: 0644
-
-- name: symlink resolv.conf
-  become: true
-  file:
-    src: /run/systemd/resolve/resolv.conf
-    dest: /etc/resolv.conf
-    state: link
-    force: true
-
-- name: Restart systemd-resolved
-  become: true
-  service:
-    name: systemd-resolved
-    enabled: true
-    state: restarted
 
 - name: Put ExecStartPost file
   become: true


### PR DESCRIPTION
Ansibleを用いて構築を行なった際にisudnsのrecordsの中身が中途半端な状況（u.isucon.devは存在するがpipeとtest01が存在しない）状況が発生しました。ログを精査したところ、以下のような問題が発生したようです。

1. pdns-serverがインストールされたタイミングでpdns.serviceが起動するも、ポート53でsystemd-resolvedが動作しており正常に起動できない
2. systemd側でpdns.serviceのrestartが行われるが、MySQL側が用意できておらずrestartを繰り返す
3. restart3回目のタイミングでAnsibleによる設定が終わりMySQLに接続ができてpdnsが起動、ExecStartPostによる `/opt/init_zone_once.sh` が実行されるが、その `/opt/init_zone_once.sh` の実行中に https://github.com/isucon/isucon13/blob/9ab011eaade23464efc766397690067d761cf75e/provisioning/ansible/roles/powerdns/tasks/main.yml#L161-L166 によるpdns.serviceの再起動が行われてレコードが中途半端になる

1の時点で正常に起動できていれば（再起動を繰り返さなければ）このような状況にはなりにくいと考えられることから、stub resolverの無効化を先に実施してからpowerdnsのセットアップをすることで回避できると考えたのでPRを作成しました。

<details>
<summary>問題発生時のログ</summary>

`u.isucon.local.` の作成後にpdnsが再起動しておりその後のスクリプトの実行がログに記録されていない。
ログは `journalctl -u pdns` で確認。

```
Jul 08 23:24:49 isucon13 systemd[1]: Starting PowerDNS Authoritative Server...
Jul 08 23:24:49 isucon13 pdns_server[216669]: Loading '/usr/lib/aarch64-linux-gnu/pdns/libbindbackend.so'
Jul 08 23:24:49 isucon13 pdns_server[216669]: This is a standalone pdns
Jul 08 23:24:49 isucon13 pdns_server[216669]: Listening on controlsocket in '/run/pdns/pdns.controlsocket'
Jul 08 23:24:49 isucon13 pdns_server[216669]: [bindbackend] Parsing 0 domain(s), will report when done
Jul 08 23:24:49 isucon13 pdns_server[216669]: [bindbackend] Done parsing domains, 0 rejected, 0 new, 0 removed
Jul 08 23:24:49 isucon13 pdns_server[216669]: Unable to bind UDP socket to '0.0.0.0:53': Address already in use
Jul 08 23:24:49 isucon13 pdns_server[216669]: Fatal error: Unable to bind to UDP socket
Jul 08 23:24:49 isucon13 systemd[1]: pdns.service: Main process exited, code=exited, status=1/FAILURE
Jul 08 23:24:49 isucon13 systemd[1]: pdns.service: Failed with result 'exit-code'.
Jul 08 23:24:49 isucon13 systemd[1]: Failed to start PowerDNS Authoritative Server.
Jul 08 23:24:50 isucon13 systemd[1]: pdns.service: Scheduled restart job, restart counter is at 1.
Jul 08 23:24:50 isucon13 systemd[1]: Stopped PowerDNS Authoritative Server.
Jul 08 23:24:50 isucon13 systemd[1]: Starting PowerDNS Authoritative Server...
Jul 08 23:24:50 isucon13 pdns_server[216888]: Unable to launch, no backends configured for querying
Jul 08 23:24:50 isucon13 systemd[1]: pdns.service: Main process exited, code=exited, status=99/n/a
Jul 08 23:24:50 isucon13 systemd[1]: pdns.service: Failed with result 'exit-code'.
Jul 08 23:24:50 isucon13 systemd[1]: Failed to start PowerDNS Authoritative Server.
Jul 08 23:24:51 isucon13 systemd[1]: pdns.service: Scheduled restart job, restart counter is at 2.
Jul 08 23:24:51 isucon13 systemd[1]: Stopped PowerDNS Authoritative Server.
Jul 08 23:24:51 isucon13 systemd[1]: Starting PowerDNS Authoritative Server...
Jul 08 23:24:51 isucon13 pdns_server[217181]: Loading '/usr/lib/aarch64-linux-gnu/pdns/libgmysqlbackend.so'
Jul 08 23:24:51 isucon13 pdns_server[217181]: [gmysqlbackend] This is the gmysql backend version 4.5.3 reporting
Jul 08 23:24:51 isucon13 pdns_server[217181]: This is a standalone pdns
Jul 08 23:24:51 isucon13 pdns_server[217181]: Listening on controlsocket in '/run/pdns/pdns.controlsocket'
Jul 08 23:24:51 isucon13 pdns_server[217181]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217181]: gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217181]: UDP server bound to 0.0.0.0:53
Jul 08 23:24:51 isucon13 pdns_server[217181]: UDP server bound to [::]:53
Jul 08 23:24:51 isucon13 pdns_server[217181]: TCP server bound to 0.0.0.0:53
Jul 08 23:24:51 isucon13 pdns_server[217181]: TCP server bound to [::]:53
Jul 08 23:24:51 isucon13 pdns_server[217181]: PowerDNS Authoritative Server 4.5.3 (C) 2001-2021 PowerDNS.COM BV
Jul 08 23:24:51 isucon13 pdns_server[217181]: Using 64-bits mode. Built using gcc 11.2.0.
Jul 08 23:24:51 isucon13 pdns_server[217181]: PowerDNS comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2.
Jul 08 23:24:51 isucon13 pdns_server[217181]: Packet cache disabled, logging queries without HIT/MISS
Jul 08 23:24:51 isucon13 pdns_server[217181]: [webserver] Listening for HTTP requests on 127.0.0.1:8081
Jul 08 23:24:51 isucon13 pdns_server[217181]: Creating backend connection for TCP
Jul 08 23:24:51 isucon13 pdns_server[217181]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217181]: gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217181]: About to create 3 backend threads for UDP
Jul 08 23:24:51 isucon13 pdns_server[217181]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217181]: gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217326]: ++ dirname /opt/init_zone_once.sh
Jul 08 23:24:51 isucon13 pdns_server[217322]: + cd /opt
Jul 08 23:24:51 isucon13 pdns_server[217322]: + test -f /home/isucon/env.sh
Jul 08 23:24:51 isucon13 pdns_server[217322]: + source /home/isucon/env.sh
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_NET=tcp
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_ADDRESS=127.0.0.1
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_PORT=3306
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_USER=isucon
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_DATABASE=isupipe
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_MYSQL_DIALCONFIG_PARSETIME=true
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_POWERDNS_SUBDOMAIN_ADDRESS=127.0.0.1
Jul 08 23:24:51 isucon13 pdns_server[217322]: ++ ISUCON13_POWERDNS_DISABLED=false
Jul 08 23:24:51 isucon13 pdns_server[217322]: + ISUCON_SUBDOMAIN_ADDRESS=127.0.0.1
Jul 08 23:24:51 isucon13 pdns_server[217328]: + pdnsutil list-all-zones
Jul 08 23:24:51 isucon13 pdns_server[217329]: + grep u.isucon.local
Jul 08 23:24:51 isucon13 pdns_server[217328]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217328]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217328]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217328]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217181]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217322]: + pdnsutil create-zone u.isucon.local
Jul 08 23:24:51 isucon13 pdns_server[217181]: gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217334]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217334]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217334]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217334]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217334]: Creating empty zone 'u.isucon.local'
Jul 08 23:24:51 isucon13 pdns_server[217334]: Jul 08 14:24:51 No serial for 'u.isucon.local' found - zone is missing?
Jul 08 23:24:51 isucon13 pdns_server[217322]: + pdnsutil add-record u.isucon.local . A 30 127.0.0.1
Jul 08 23:24:51 isucon13 pdns_server[217335]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217335]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:51 isucon13 pdns_server[217335]: WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
Jul 08 23:24:51 isucon13 pdns_server[217335]: Jul 08 14:24:51 gmysql Connection successful. Connected to database 'isudns' on '127.0.0.1'.
Jul 08 23:24:52 isucon13 pdns_server[217335]: New rrset:
Jul 08 23:24:52 isucon13 pdns_server[217335]: u.isucon.local. 30 IN A 127.0.0.1
Jul 08 23:24:52 isucon13 systemd[1]: pdns.service: Control process exited, code=killed, status=15/TERM
Jul 08 23:24:52 isucon13 systemd[1]: pdns.service: Failed with result 'signal'.
Jul 08 23:24:52 isucon13 systemd[1]: Stopped PowerDNS Authoritative Server.
Jul 08 23:24:52 isucon13 systemd[1]: Starting PowerDNS Authoritative Server...
Jul 08 23:24:52 isucon13 pdns_server[217341]: Loading '/usr/lib/aarch64-linux-gnu/pdns/libgmysqlbackend.so'
Jul 08 23:24:52 isucon13 pdns_server[217341]: [gmysqlbackend] This is the gmysql backend version 4.5.3 reporting
Jul 08 23:24:52 isucon13 pdns_server[217341]: This is a standalone pdns
```

</details>