### PR TITLE
python: do not use python_full_version

### DIFF
--- a/webapp/python/Pipfile
+++ b/webapp/python/Pipfile
@@ -18,4 +18,3 @@ mypy = "*"
 
 [requires]
 python_version = "3.12"
-python_full_version = "3.12.0"


### PR DESCRIPTION
PythonのDockerfileで `FROM python:3.12-bookworm` をしているので、Dockerでは3.12系の最新版を利用しています。
一方でPipfileの方では完全バージョン指定しているので、バージョンミスマッチで開発環境を動かせませんでした。

```
 => ERROR [webapp 10/12] RUN pipenv install                                                                                                                                                                 0.4s
------
 > [webapp 10/12] RUN pipenv install:
0.358 Warning: Python 3.12.0 was not found on your system...
0.359 Neither 'pyenv' nor 'asdf' could be found to install Python.
0.359 You can specify specific versions of Python with:
0.360 $ pipenv --python path/to/python
------
failed to solve: process "/bin/sh -c pipenv install" did not complete successfully: exit code: 1
```

python_full_version指定を外すだけで docker compose up が成功するようになりました。